### PR TITLE
return mock WIT service in servicefactory

### DIFF
--- a/authorization/invitation/service/invitation_service.go
+++ b/authorization/invitation/service/invitation_service.go
@@ -267,7 +267,6 @@ func (s *invitationServiceImpl) processTeamInviteNotifications(ctx context.Conte
 // processSpaceInviteNotifications sends an e-mail notification to a user.
 func (s *invitationServiceImpl) processSpaceInviteNotifications(ctx context.Context, space *resource.Resource,
 	inviterName string, notifications []invitationNotification) error {
-
 	sp, err := s.Services().WITService().GetSpace(ctx, space.ResourceID)
 	if err != nil {
 		return err

--- a/gormapplication/application.go
+++ b/gormapplication/application.go
@@ -49,14 +49,14 @@ const (
 
 //var y application.Application = &GormTransaction{}
 
-func NewGormDB(db *gorm.DB, config *configuration.ConfigurationData) *GormDB {
-	val := new(GormDB)
-	val.db = db.Set("gorm:save_associations", false)
-	val.txIsoLevel = ""
-	val.serviceFactory = factory.NewServiceFactory(func() context.ServiceContext {
-		return factory.NewServiceContext(val, val, config)
-	}, config)
-	return val
+func NewGormDB(db *gorm.DB, config *configuration.ConfigurationData, options ...factory.Option) *GormDB {
+	g := new(GormDB)
+	g.db = db.Set("gorm:save_associations", false)
+	g.txIsoLevel = ""
+	g.serviceFactory = factory.NewServiceFactory(func() context.ServiceContext {
+		return factory.NewServiceContext(g, g, config, options...)
+	}, config, options...)
+	return g
 }
 
 // GormBase is a base struct for gorm implementations of db & transaction

--- a/gormtestsupport/db_test_suite.go
+++ b/gormtestsupport/db_test_suite.go
@@ -59,6 +59,7 @@ func (s *DBTestSuite) SetupSuite() {
 			}, "failed to connect to the database")
 		}
 	}
+	// TODO(xcoulon): use an env variable to avoid systematic logging of all SQL requests?
 	s.DB = s.DB.Debug()
 	gormDB := gormapplication.NewGormDB(s.DB, configuration)
 	s.GormDB = gormDB


### PR DESCRIPTION
use a function to specify the value to return when calling the `WITService()` method on the service factory, then add an option in the constructor to override the default `WITService` to return.

Signed-off-by: Xavier Coulon <xcoulon@redhat.com>
